### PR TITLE
Add login/logout status messages and redirect to profile on successful login

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -205,6 +205,15 @@ nav {
   background-color: #6aa8ff; /* Even lighter blue */
 }
 
+.account .status-message {
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 0.9rem;
+}
+
 /* Utility classes */
 .center {
   text-align: center;

--- a/src/components/Account.jsx
+++ b/src/components/Account.jsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import AccountDetails from "./AccountDetails";
 
+const API_URL = import.meta.env.VITE_API_URL || "https://travelbug-2.onrender.com";
+
 const Account = () => {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     registerName: "",
     registerEmail: "",
@@ -12,6 +16,7 @@ const Account = () => {
   });
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [error, setError] = useState(null);
+  const [statusMessage, setStatusMessage] = useState("");
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -36,7 +41,7 @@ const Account = () => {
         password: formData.registerPassword,
       });
   
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/register`, {
+      const response = await fetch(`${API_URL}/auth/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -54,14 +59,17 @@ const Account = () => {
         localStorage.setItem('token', data.token);
         setIsLoggedIn(true);
         setError(null);
+        setStatusMessage("Registration successful. You are now logged in.");
         window.dispatchEvent(new Event("auth-change"));
       } else {
         console.error('Registration failed:', data.error);
         setError(data.error || 'Registration failed.');
+        setStatusMessage("");
       }
     } catch (error) {
       console.error('Error during registration:', error.message);
       setError('An unexpected error occurred. Please try again.');
+      setStatusMessage("");
     }
   };
   
@@ -69,7 +77,7 @@ const Account = () => {
   const login = async (e) => {
     e.preventDefault();
     try {
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/login`, {
+      const response = await fetch(`${API_URL}/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -82,13 +90,17 @@ const Account = () => {
         localStorage.setItem("token", data.token);
         setIsLoggedIn(true);
         setError(null);
+        setStatusMessage("Login successful. Redirecting to your profile...");
         window.dispatchEvent(new Event("auth-change"));
+        navigate("/myprofile");
       } else {
         setError(data.message || "Login failed. Please check your credentials.");
+        setStatusMessage("");
       }
     } catch (error) {
       console.error("Error during login:", error);
       setError("An unexpected error occurred during login.");
+      setStatusMessage("");
     }
   };
 
@@ -96,6 +108,7 @@ const Account = () => {
     localStorage.removeItem("token");
     setIsLoggedIn(false);
     setError(null);
+    setStatusMessage("You have been logged out successfully.");
     window.dispatchEvent(new Event("auth-change"));
   };
 
@@ -103,6 +116,7 @@ const Account = () => {
     <div className="account">
       {isLoggedIn ? (
         <>
+          {statusMessage && <p className="status-message">{statusMessage}</p>}
           <AccountDetails />
           <button onClick={logOut}>Logout</button>
         </>
@@ -111,6 +125,7 @@ const Account = () => {
           <form onSubmit={register}>
             <h1>New User Registration</h1>
             {error && <p className="error-message">{error}</p>}
+            {statusMessage && <p className="status-message">{statusMessage}</p>}
             <input
               type="text"
               name="registerName"
@@ -147,6 +162,7 @@ const Account = () => {
           <form onSubmit={login}>
             <h1>Login</h1>
             {error && <p className="error-message">{error}</p>}
+            {statusMessage && <p className="status-message">{statusMessage}</p>}
             <input
               type="email"
               name="inputEmail"

--- a/src/components/AccountDetails.jsx
+++ b/src/components/AccountDetails.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+const API_URL = import.meta.env.VITE_API_URL || 'https://travelbug-2.onrender.com';
+
 const AccountDetails = () => {
   const [userDetails, setUserDetails] = useState(null);
   const [error, setError] = useState(null);
@@ -14,7 +16,7 @@ const AccountDetails = () => {
           return;
         }
   
-        const response = await fetch(`${import.meta.env.VITE_API_URL}/users/me`, {
+        const response = await fetch(`${API_URL}/users/me`, {
           headers: {
             Authorization: `Bearer ${token}`,
           },


### PR DESCRIPTION
### Motivation
- Provide clear user feedback for authentication actions so users know when registration, login, or logout succeeded or failed.
- Immediately navigate users to their profile after a successful login to improve the UX and match expected behavior.
- Ensure fetch calls consistently fall back to a default API base URL when `VITE_API_URL` is not set.

### Description
- Added a shared `API_URL` fallback (`import.meta.env.VITE_API_URL || 'https://travelbug-2.onrender.com'`) and updated `fetch` calls in `src/components/Account.jsx` and `src/components/AccountDetails.jsx` to use `API_URL` for `/auth/*` and `/users/me` requests.
- Introduced `statusMessage` state in `src/components/Account.jsx`, set messages for registration, login, and logout outcomes, and rendered them in the account and form views via `<p className="status-message">`.
- On successful login the code now calls `navigate('/myprofile')` (using `useNavigate`) so users are immediately redirected to their profile page.
- Added CSS rules in `src/App.css` for `.account .status-message` to visually highlight status feedback.

### Testing
- Started the dev server (`vite`) and ran a Playwright script that injected a token, mocked the `/users/me` response, navigated to `/account`, clicked the `Logout` button, and verified the logout status message appeared, which succeeded and produced a screenshot artifact.
- Manual smoke run performed while developing (dev server started) to validate navigation and UI changes; no unit tests or formal test suite were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7f596350832386152f332d02e709)