### PR TITLE
Show auth status messages and display login success on profile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -205,6 +205,25 @@ nav {
   background-color: #6aa8ff; /* Even lighter blue */
 }
 
+.account .status-message {
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 0.9rem;
+}
+
+.account-details .status-message {
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  border-radius: 6px;
+  padding: 10px;
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+}
+
 /* Utility classes */
 .center {
   text-align: center;

--- a/src/components/Account.jsx
+++ b/src/components/Account.jsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import AccountDetails from "./AccountDetails";
 
+const API_URL = import.meta.env.VITE_API_URL || "https://travelbug-2.onrender.com";
+
 const Account = () => {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     registerName: "",
     registerEmail: "",
@@ -12,6 +16,7 @@ const Account = () => {
   });
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [error, setError] = useState(null);
+  const [statusMessage, setStatusMessage] = useState("");
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -36,7 +41,7 @@ const Account = () => {
         password: formData.registerPassword,
       });
   
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/register`, {
+      const response = await fetch(`${API_URL}/auth/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -54,14 +59,17 @@ const Account = () => {
         localStorage.setItem('token', data.token);
         setIsLoggedIn(true);
         setError(null);
+        setStatusMessage("Registration successful. You are now logged in.");
         window.dispatchEvent(new Event("auth-change"));
       } else {
         console.error('Registration failed:', data.error);
         setError(data.error || 'Registration failed.');
+        setStatusMessage("");
       }
     } catch (error) {
       console.error('Error during registration:', error.message);
       setError('An unexpected error occurred. Please try again.');
+      setStatusMessage("");
     }
   };
   
@@ -69,7 +77,7 @@ const Account = () => {
   const login = async (e) => {
     e.preventDefault();
     try {
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/login`, {
+      const response = await fetch(`${API_URL}/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -82,13 +90,19 @@ const Account = () => {
         localStorage.setItem("token", data.token);
         setIsLoggedIn(true);
         setError(null);
+        setStatusMessage("Login successful. Redirecting to your profile...");
         window.dispatchEvent(new Event("auth-change"));
+        navigate("/myprofile", {
+          state: { message: "Login successful. Welcome back!" },
+        });
       } else {
         setError(data.message || "Login failed. Please check your credentials.");
+        setStatusMessage("");
       }
     } catch (error) {
       console.error("Error during login:", error);
       setError("An unexpected error occurred during login.");
+      setStatusMessage("");
     }
   };
 
@@ -96,6 +110,7 @@ const Account = () => {
     localStorage.removeItem("token");
     setIsLoggedIn(false);
     setError(null);
+    setStatusMessage("You have been logged out successfully.");
     window.dispatchEvent(new Event("auth-change"));
   };
 
@@ -103,6 +118,7 @@ const Account = () => {
     <div className="account">
       {isLoggedIn ? (
         <>
+          {statusMessage && <p className="status-message">{statusMessage}</p>}
           <AccountDetails />
           <button onClick={logOut}>Logout</button>
         </>
@@ -111,6 +127,7 @@ const Account = () => {
           <form onSubmit={register}>
             <h1>New User Registration</h1>
             {error && <p className="error-message">{error}</p>}
+            {statusMessage && <p className="status-message">{statusMessage}</p>}
             <input
               type="text"
               name="registerName"
@@ -147,6 +164,7 @@ const Account = () => {
           <form onSubmit={login}>
             <h1>Login</h1>
             {error && <p className="error-message">{error}</p>}
+            {statusMessage && <p className="status-message">{statusMessage}</p>}
             <input
               type="email"
               name="inputEmail"

--- a/src/components/AccountDetails.jsx
+++ b/src/components/AccountDetails.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+const API_URL = import.meta.env.VITE_API_URL || 'https://travelbug-2.onrender.com';
+
 const AccountDetails = () => {
   const [userDetails, setUserDetails] = useState(null);
   const [error, setError] = useState(null);
@@ -14,7 +16,7 @@ const AccountDetails = () => {
           return;
         }
   
-        const response = await fetch(`${import.meta.env.VITE_API_URL}/users/me`, {
+        const response = await fetch(`${API_URL}/users/me`, {
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import CreatePost from "./CreatePost";
 
 const MyProfile = () => {
+  const location = useLocation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [profileMessage, setProfileMessage] = useState("");
   const [user] = useState({
     userId: 1,
     username: "henry",
@@ -90,8 +92,15 @@ const MyProfile = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (location.state?.message) {
+      setProfileMessage(location.state.message);
+    }
+  }, [location.state]);
+
   return (
     <div className="account-details">
+      {profileMessage && <p className="status-message">{profileMessage}</p>}
       <h2>Welcome, {user.username}!</h2>
       <div className="user-info">
         <p>


### PR DESCRIPTION
### Motivation
- Users were not getting any visible confirmation after registration, login, or logout, making the auth flow unclear and inconsistent.
- The codebase needed a consistent API base URL fallback so client fetches reliably target the backend when `VITE_API_URL` is not set.

### Description
- Added `API_URL = import.meta.env.VITE_API_URL || 'https://travelbug-2.onrender.com'` and migrated fetch calls in `src/components/Account.jsx` and `src/components/AccountDetails.jsx` to use `API_URL`.
- Introduced `statusMessage` state in `src/components/Account.jsx` and set it for registration success, login success, and logout so the account page shows feedback via `<p className="status-message">`.
- On successful login the code now calls `navigate('/myprofile', { state: { message: 'Login successful. Welcome back!' } })` and `src/components/MyProfile.jsx` reads `location.state?.message` (via `useLocation`) to display the success banner on the profile page.
- Added CSS rules for `.account .status-message` and `.account-details .status-message` in `src/App.css` to style the feedback banners consistently.

### Testing
- Started the dev server with `npm run dev` and confirmed the app served successfully.
- Ran a Playwright end-to-end script that mocked `/users/me` and `/auth/login`, exercised logout and login flows, and verified the profile page displays the login success banner; this run succeeded and produced `artifacts/profile-login-status.png`.
- Two earlier Playwright attempts failed (one timed out and one failed due to an ambiguous locator), and those issues were resolved by updating the test script selectors before the successful run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7f596350832386152f332d02e709)